### PR TITLE
Upgrade to BabylonJS 2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "bluebird": "~2.9.13",
     "angular-route": "~1.3.14",
     "angular-mocks": "~1.3.14",
-    "babylonjs": "git://github.com/BabylonJS/Babylon.js.git#v2.0",
+    "babylonjs": "git://github.com/BabylonJS/Babylon.js.git#v2.1",
     "Keypress": "~2.1.0",
     "socket.io-client": "~1.3.5",
     "eventemitter2": "~0.4.14",

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
         <script src="/vendor/path/path.min.js"></script>
 
         <!-- Babylon.js -->
-        <script src="/vendor/babylonjs/babylon.2.0.js"></script>
+        <script src="/vendor/babylonjs/babylon.2.1.js"></script>
         <script src="/vendor/handjs/hand-1.3.8.js"></script>
 
         <!-- Keypress.js -->


### PR DESCRIPTION
Since Babylon.JS broke Bower support for their 2.0 series by pushing a "v2.0.0" tag that actually has 2.1 in it, we need to upgrade in order for new checkouts to get up and running correctly.