### PR TITLE
Use Travis CI's Container-based environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ before_script:
   - bower install
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  
+
 notifications:
-  slack: skewedaspect:zINIXYjK8YSDFl0RMzjYhKYr 
+  slack: skewedaspect:zINIXYjK8YSDFl0RMzjYhKYr
+
+# Turn off `sudo` support in order to use Travis CI's Container-based environment.
+# See http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+sudo: false


### PR DESCRIPTION
Disabling `sudo` allows us to use the slightly faster Container-based environment, as described at <http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments>.